### PR TITLE
Handle missing curriculum artifacts and create test screenshot

### DIFF
--- a/.github/workflows/curriculum.yml
+++ b/.github/workflows/curriculum.yml
@@ -14,6 +14,8 @@ jobs:
           LEVEL: ${{ inputs.LEVEL || '' }}   # 可手動指定；預設依 run 次數遞增
           SEED:  ${{ github.sha }}          # 讓每個 commit 可重現
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: diagrams
           path: test-output/*.png
+          if-no-files-found: ignore

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "lint": "eslint js",
+    "lint": "eslint js test-curriculum.js",
     "test": "npm run lint && npm run test:curriculum",
     "test:curriculum": "node test-curriculum.js"
   },

--- a/test-curriculum.js
+++ b/test-curriculum.js
@@ -1,5 +1,6 @@
 const { chromium } = require('playwright');
 const path = require('path');
+const fs = require('fs');
 
 (async () => {
   const browser = await chromium.launch();
@@ -7,6 +8,9 @@ const path = require('path');
   const filePath = path.join(__dirname, 'index.html');
   await page.goto('file://' + filePath);
   await page.waitForSelector('#btnRender');
+  const outDir = path.join(__dirname, 'test-output');
+  fs.mkdirSync(outDir, { recursive: true });
+  await page.screenshot({ path: path.join(outDir, 'smoke.png'), fullPage: true });
   await browser.close();
   console.log('Curriculum smoke test completed');
 })();


### PR DESCRIPTION
## Summary
- Capture a screenshot during the curriculum smoke test and save it under `test-output`
- Always upload diagram artifacts in CI, even if screenshots are missing
- Lint the curriculum smoke test script along with other sources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6c193e714832f8cd2b80f7dea31c1